### PR TITLE
Added feature for allowed users by group in redmine

### DIFF
--- a/redmineauth/jenkins.py
+++ b/redmineauth/jenkins.py
@@ -18,7 +18,13 @@ def main():
         sys.exit(1)
     user = os.environ['U']
     password = os.environ['P']
-    result = check_password_conn_str(args.conn_str, user, password)
+
+    if 'G' not in os.environ:
+        groups = ''
+    else:
+        groups = os.environ['G']
+
+    result = check_password_conn_str(args.conn_str, user, password, groups)
     if result:
         print 'succ'
         sys.exit(0)

--- a/redmineauth/main.py
+++ b/redmineauth/main.py
@@ -11,10 +11,11 @@ DB_CONFIG = {{
     "user" : "{user}",
     "pw" : "{pw}",
     "db" : "{db}",
+    "groups" : "{groups}",
 }}
 
-def check_password(environ, user, password):
-    return redmineauth.check_password(DB_CONFIG, user, password)
+def check_password(environ, user, password, groups):
+    return redmineauth.check_password(DB_CONFIG, user, password, groups)
 '''
 
 def main():
@@ -41,6 +42,8 @@ def main():
     settings['pw'] = t.strip()
     t = raw_input('Redmine Database Name [redmine]:')
     settings['db'] = t if t.strip() else 'redmine'
+    t = raw_input('Redmine user group that is allowed repository access. multiple groups can use separator (,) []:')
+    settings['groups'] = t if t.strip() else ''
 
     args.config_file.write(wsgi_template.format(**settings))
 


### PR DESCRIPTION
Hi @laiyonghao 

Thanks for creating this source code for python. i have used this source code with `Debian GNU/Linux 10 (buster)` os running through docker container smoothly.
let me make a small contribution to your source code.
the logic that I applied to your source code can also be used by everyone who needs its functionality.

Here's the explanation:
1. Added a group variable to the configuration for the filter in the query section retrieving users with the condition that the user must be registered in the group set up as repository authentication.
2. Added a new query to fetch users by group, group state, and user state.
3. Users and groups must be active
4. Can multiple groups that are defined as authentication repositories
5. The group can be filled during database configuration in the "redmine_auth -g WSGI-FILE-PATH" section and can be left blank if not used
6. If the group is empty, then the function logic will point to the default query from the source code
